### PR TITLE
added docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,57 @@
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get -y upgrade && apt-get -y install \
+	vim \
+	git \ 
+	git-core \
+	wget \
+	unzip \
+	cmake \
+	gdal-bin \
+	libgdal-dev \
+	build-essential
+
+WORKDIR /root
+
+# Add the repository
+ADD ./* /root/lidarhd_ign_downloader/
+
+# Install conda and dependencies
+SHELL ["/bin/bash", "-c"]
+RUN mkdir -p ~/miniconda3 && \
+	wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda3/miniconda.sh && \
+	bash ~/miniconda3/miniconda.sh -b -u -p ~/miniconda3 && \
+	rm ~/miniconda3/miniconda.sh && \
+	source ~/miniconda3/bin/activate && \
+	conda install -y -n base -c conda-forge mamba pdal python-pdal gdal && \
+	cd lidarhd_ign_downloader && \
+	mamba env create -f pdal_env.yml
+
+# Set environment variables
+ENV HOME="/root"
+ENV LIDAR_PATH="${HOME}/lidarhd_ign_downloader"
+ENV PATH="${LIDAR_PATH}:${PATH}"            
+ENV PYTHONPATH="${PYTHONPATH}:${LIDAR_PATH}"
+ENV PATH="${HOME}/miniconda3/bin:$PATH"
+
+# Install PDAL Wrench
+RUN cd ~ && \
+	git clone https://github.com/PDAL/wrench.git && \
+	cd wrench && \
+	mkdir build && \
+	cd build && \
+	cmake .. && \
+	make
+
+ENV PDWRENCH="${HOME}/wrench/build/"
+ENV PATH="${PDWRENCH}:${PATH}"
+
+# Set the working directory
+RUN chmod +x ~/lidarhd_ign_downloader/lidar_downloader.py
+WORKDIR /root/lidarhd_ign_downloader
+RUN conda init bash \
+	&& echo -e "\nconda activate pdal_env" >> ~/.bashrc \
+	&& echo "echo \"Lidar HD IGN downloader\"" >>  ~/.bashrc \
+	&& echo "echo \"Type lidar_downloader.py -h to access to the help of the tool\"" >>  ~/.bashrc \
+	&& conda clean -a
+

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Refer to [IGN-France website](https://geoservices.ign.fr/lidarhd) for news about
 3. [Installation](#installation)
 4. [Pdal_wrench installation (optional but very useful)](#pdal_wrench-installation-optional)
 5. [How to use](#how-to-use)
-6. [Contact and citation](#contact-and-citation)
+6. [Use with Docker](#use-with-docker)
+7. [Contact and citation](#contact-and-citation)
 
 ## Required packages
 - python (conda) environment
@@ -199,6 +200,26 @@ lidar_downloader.main(args)
 
 > [!NOTE]   
 > Whatever the case, the script will iterate through all the features (polygons) within the shapefile or geopackage file. It will create a folder for each specific AOI based on the column with the `aoi_name`. If you used your own shapefile, make sure to have one column called `aoi_name`. Otherwise, you can edit the provided file.
+
+## USE WITH DOCKER
+
+Build docker image with: `docker build . -t bilbud/lidarhd_ign_downloader`
+
+Or pull image from Docker Hub: `docker pull bilbud/lidarhd_ign_downloader`
+
+Run with: 
+```
+docker run -it \
+-v $(pwd)/aoi_example.gpkg:/aoi_file.gpkg \
+-v $(pwd)/data/out:/data/out/ \
+bilbud/lidarhd_ign_downloader
+```
+
+Once in the shell, interact with CLI as described in [How to use](#how-to-use).
+
+Example:
+
+`lidar_downloader.py /aoi_file.gpkg -out_data /data/out/ -tr 1 -compute_elev mean -dtype gtif -rm_tiles -pdensity -cpu_w 0.6`
 
 # Contact and citation ![DOI](https://zenodo.org/badge/706232299.svg)
 For any question/bug/issue regarding this tool, please report it on issues section or contact [diego.cusicanqui@univ-grenoble-alpes.fr](mailto:diego.cusicanqui@univ-grenoble-alpes.fr).


### PR DESCRIPTION
Hello,
here is a Docker File to be able to use your tool without installing all the dependencies.

As described in the updated README:

Build docker image with: `docker build . -t bilbud/lidarhd_ign_downloader`

Or pull image from Docker Hub: `docker pull bilbud/lidarhd_ign_downloader`

Run with: 
```
docker run -it \
-v $(pwd)/aoi_example.gpkg:/aoi_file.gpkg \
-v $(pwd)/data/out:/data/out/ \
bilbud/lidarhd_ign_downloader
```

Once in the shell, interact with CLI as described in [How to use](#how-to-use).

Example:

`lidar_downloader.py /aoi_file.gpkg -out_data /data/out/ -tr 1 -compute_elev mean -dtype gtif -rm_tiles -pdensity -cpu_w 0.6`


I hope you or users will find this useful, especially for non python developers.

Feel free to contact me for further discussion.
Regards,
Bruce